### PR TITLE
Update Native Apple

### DIFF
--- a/privacy/native/apple
+++ b/privacy/native/apple
@@ -4,3 +4,5 @@ supportmetrics.apple.com
 metrics.icloud.com
 metrics.mzstatic.com
 dzc-metrics.mzstatic.com
+books-analytics-events.news.apple-dns.net
+books-analytics-events.apple.com


### PR DESCRIPTION
- Include:

- `books-analytics-events.news.apple-dns.net`
- `books-analytics-events.apple.com`
- [x] Blocking each does not interfere with any proper Apple Books functionality; each is used solely for phoning home with analytics. Moreover, Apple Books (very) frequently sends analytics to Apple using each of the two proposed additional host names.
 
- Additional information:

`books-analytics-events.news.apple-dns.net.` **`CNAME`** `books-analytics-events.apple.com`